### PR TITLE
InfoAreaの追加

### DIFF
--- a/Board.pde
+++ b/Board.pde
@@ -1,0 +1,19 @@
+class Board {
+  BaseArea bArea;
+  InfoArea iArea;
+  MochigomaArea[] mArea = new MochigomaArea[2];
+
+  Board(){
+    bArea = new BaseArea(1,0,4,3);
+    iArea = new InfoArea(1,3,4,1);
+    mArea[0] = new MochigomaArea(0,0,1,4);
+    mArea[1] = new MochigomaArea(5,0,1,4);
+  }
+
+  void draw(){
+    bArea.draw();
+    mArea[0].draw();
+    mArea[1].draw();
+    iArea.draw();
+  }
+}

--- a/InfoArea.pde
+++ b/InfoArea.pde
@@ -1,0 +1,12 @@
+class InfoArea extends AbstractArea {
+  InfoArea(int posX, int posY, int yoko, int tate) {
+    super(posX, posY, yoko, tate);
+  }
+  void draw() {
+    fill(#FFFFFF);
+    rect(posX*SQUARESIZE, posY*SQUARESIZE, yoko*SQUARESIZE, tate*SQUARESIZE);
+    fill(#000000);
+    textSize(20);
+    text("<- Left turn", (posX+0.3)*SQUARESIZE, (posY+0.5)*SQUARESIZE);
+  }
+}


### PR DESCRIPTION
InfoAreaクラスを作成する
AbstractAreaクラスを継承する．
親クラス（AbstractAreaクラス）で定義されたエリアの左上座標(poX, posY)と縦幅(tate)，横幅(yoko)を親クラスのコンストラクタ(super(int posX, int posY, int yoko, int tate))を利用して初期化する．
親クラスで定義された抽象メソッドvoid draw()を実装する．
エリア内は白字に黒文字．
起動時はLeftのTurnであることを示す文字を左寄りに表示する